### PR TITLE
-added endpoints for adding a meal option

### DIFF
--- a/API/Dummydb/dummydb.js
+++ b/API/Dummydb/dummydb.js
@@ -28,5 +28,4 @@ export default {
       price: '1,500',
     },
   ],
-}
-;
+};

--- a/API/controller/mealController.js
+++ b/API/controller/mealController.js
@@ -1,5 +1,17 @@
+import Joi from 'joi';
 import dummydb from '../Dummydb/dummydb';
 
+const validateMeal = (meals) => {
+  const schema = {
+    name: Joi.string().min(3).required(),
+    size: Joi.string().required(),
+    price: Joi.number().integer().min(500).max(3000).required(),
+  };
+
+  return Joi.validate(meals, schema);
+};
+
+// TO GET ALL MEAL OPTIONS
 const getAllMeals = (req, res) => {
   res.json({
     status: 200,
@@ -7,9 +19,30 @@ const getAllMeals = (req, res) => {
   });
 };
 
+// TO ADD A MEAL OPTION
+const addMeal = (req, res) => {
+  const { error } = validateMeal(req.body);
+  if (error) {
+    return res.status(400).send(error.details[0].message);
+  }
+
+  const meal = {
+    id: dummydb.meals.length + 1,
+    name: dummydb.meals.name,
+    size: req.body.size,
+    price: req.body.price,
+  };
+
+  dummydb.meals.push(meal);
+  res.json({
+    status: 201,
+    data: meal,
+  });
+};
 
 const control = {
   getAllMeals,
+  addMeal,
 };
 
 export { control };

--- a/API/index.js
+++ b/API/index.js
@@ -6,12 +6,12 @@ const app = Express();
 
 const PORT = process.env.PORT || 8080;
 
+app.use(bodyParser.urlencoded({ extended: false }));
+
 app.use(bodyParser.json());
 
 app.use(mealRoute);
 
-app.listen( PORT, () => {
-
+app.listen(PORT, () => {
   console.log(`server is running on port ${PORT}`);
-
 });

--- a/API/route/mealRoute.js
+++ b/API/route/mealRoute.js
@@ -5,5 +5,6 @@ import { control } from '../controller/mealController';
 const app = Express.Router();
 
 app.get('/api/v1/meals/', control.getAllMeals);
+app.post('/api/v1/meals', control.addMeal);
 
 export default app;


### PR DESCRIPTION
#### What does this PR do?
Endpoint for adding a meal option
#### Description of Task to be completed?
none
#### How should this be manually tested?
Using postman, send a fill in name, size and price field then send a post request to /api/v1/meals/
#### Any background context you want to provide?
none
#### What are the relevant pivotal tracker stories?
API endpoint to add a meal option
#### Screenshots (if appropriate)
none
#### Questions:
none